### PR TITLE
Dockerfile: use alpine 3.12 instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-FROM docker.io/library/alpine:3.13.5@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f
+FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
 
 RUN apk add --no-cache curl iputils
 ENTRYPOINT ["/usr/bin/curl"]


### PR DESCRIPTION
In Alpine 3.11 and 3.13, 'nslookup' exits with the error code 1 if it
can't resolve all IPs for the search list defined in /etc/resolv.conf

However, it seems that Alpine 3.10 and 3.12 are not affected by this bug
and continue return the error code 0 if at least on of the domains in
the search list is resolved into an IP address. Thus, we will use the
latest Alpine image available for the 3.12 release series.

Fixes: e868890c748f ("upload image digests artifacts")
Signed-off-by: André Martins <andre@cilium.io>