### PR TITLE
Update alpine to 3.16.2 and let dependabot perform future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: daily
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
 # TARGETARCH
-# Do not upgrade to alpine 3.13 as its nslookup tool returns 1, instead of 0
-# for domain name lookups.
-FROM docker.io/library/alpine:3.12.7@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
+FROM docker.io/library/alpine:3.16.2@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad
 
 RUN apk add --no-cache curl iputils bind-tools
 ENTRYPOINT ["/usr/bin/curl"]


### PR DESCRIPTION
We're using nslookup from bind-tools now (c.f. https://github.com/cilium/alpine-curl/pull/14) so the comment re. nslookup in alpine ͥ≥ 3.13 no longer applies.

Also let dependabot perform future base image updates.
    
