### PR TITLE
Add tcpdump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@
 # TARGETARCH
 FROM docker.io/library/alpine:3.16.3@sha256:b95359c2505145f16c6aa384f9cc74eeff78eb36d308ca4fd902eeeb0a0b161b
 
-RUN apk add --no-cache curl iputils bind-tools
+RUN apk add --no-cache curl iputils bind-tools tcpdump
 ENTRYPOINT ["/usr/bin/curl"]


### PR DESCRIPTION
It's going to be used by encryption tests in cilium-cli.

Signed-off-by: Martynas Pumputis <m@lambda.lt>