### PR TITLE
Dockerfile: Add dnsperf tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,31 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
-# Represents the plataform where the build is happening, do not mix with
+# Represents the platform where the build is happening, do not mix with
 # TARGETARCH
-FROM docker.io/library/alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
 
-RUN apk add --no-cache curl iputils bind-tools tcpdump
+# Stage 1: install dnsperf and its build dependencies
+FROM docker.io/library/alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1 as dnsperf-builder
+
+ARG DNSPERF_VERSION=2.13.0
+
+RUN apk update \
+    && apk add curl tar \
+    && apk add build-base gcc libtool ldns-dev ck-dev nghttp2-dev openssl-dev
+
+# Install dnsperf
+RUN curl -L https://www.dns-oarc.net/files/dnsperf/dnsperf-${DNSPERF_VERSION}.tar.gz --output dnsperf-${DNSPERF_VERSION}.tar.gz \
+    && tar zxvf dnsperf-${DNSPERF_VERSION}.tar.gz \
+    && cd dnsperf-${DNSPERF_VERSION}  \
+    && ./configure \
+    && make \
+    && make install
+
+# Stage 2: install needed binaries
+FROM docker.io/library/alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
+# Copy dnsperf binary from the previous stage
+COPY --from=dnsperf-builder /usr/local/bin/dnsperf /usr/bin/dnsperf
+RUN apk add --no-cache curl iputils bind-tools tcpdump  \
+    && apk add --no-cache ldns-dev libssl3 libcrypto3 nghttp2-libs # explicit dependencies for dnsperf
+
 ENTRYPOINT ["/usr/bin/curl"]


### PR DESCRIPTION
Add dnsperf tool to use in cilium-cli connectivity tests.

### Test

Changed the entrypoint for the test `ENTRYPOINT ["/usr/bin/dnsperf"]`

```
$ docker build  -t cilium-alpine --progress=plain .

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 1.57kB done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s

#3 resolve image config for docker.io/docker/dockerfile:1.2
#3 DONE 1.1s

#4 docker-image://docker.io/docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
#4 CACHED

#5 [internal] load metadata for docker.io/library/alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
#5 DONE 0.8s

#6 [stage-1 1/3] FROM docker.io/library/alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
#6 DONE 0.0s

#7 [dnsperf-builder 2/4] RUN apk update     && apk add curl tar     && apk add ldns-dev ck-dev build-base gcc libtool
#7 CACHED

#8 [dnsperf-builder 3/4] RUN curl -L -O https://github.com/nghttp2/nghttp2/releases/download/v1.54.0/nghttp2-1.54.0.tar.gz     && tar zxvf nghttp2-1.54.0.tar.gz     && cd nghttp2-1.54.0     &&  ./configure     && make install
#8 CACHED

#9 [dnsperf-builder 4/4] RUN curl -L https://www.dns-oarc.net/files/dnsperf/dnsperf-2.13.0.tar.gz --output dnsperf-2.13.0.tar.gz     && tar zxvf dnsperf-2.13.0.tar.gz     && cd dnsperf-2.13.0      && ./configure     && make     && make install
#9 CACHED

#10 [stage-1 2/3] COPY --from=dnsperf-builder /usr/local/bin/dnsperf /usr/bin/dnsperf
#10 CACHED

#11 [stage-1 3/3] RUN apk add --no-cache curl iputils bind-tools tcpdump ldns-dev
#11 CACHED

#12 exporting to image
#12 exporting layers done
#12 writing image sha256:807e7e4ab60d043d4aac44c45cd128b215548db2fe2d154451684dd5c6d9529f done
#12 naming to docker.io/library/cilium-alpine done
#12 DONE 0.0s
```

Run
```
 $ docker run cilium-alpine
 DNS Performance Testing Tool
Version 2.13.0
Usage: dnsperf [-f family] [-m mode] [-s server_addr] [-p port]
...
```