### PR TITLE
Add iproute2

### DIFF
--- a/.github/workflows/image-prs.yaml
+++ b/.github/workflows/image-prs.yaml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
         with:
           path: image-digest/
+          pattern: "*image-digest *"
 
       - name: Image Digests Output
         shell: bash

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -85,6 +85,7 @@ jobs:
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
         with:
           path: image-digest/
+          pattern: "*image-digest *"
 
       - name: Image Digests Output
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ FROM registry.k8s.io/pause:3.10@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f50
 # TARGETARCH
 FROM docker.io/library/alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
 COPY --from=pause /pause /usr/bin/pause
-RUN apk add --no-cache curl iputils bind-tools tcpdump
+RUN apk add --no-cache curl iputils bind-tools tcpdump iproute2
 ENTRYPOINT ["/usr/bin/curl"]


### PR DESCRIPTION
Busybox's "ip route" does not show MTU. The MTU is going to be needed by upcoming cilium-cli connectivity tests to check for IP fragmentation when encryption is enabled.